### PR TITLE
Fix sell price greater than buy price error

### DIFF
--- a/backend/middleware/validation.js
+++ b/backend/middleware/validation.js
@@ -105,18 +105,8 @@ export const validateProductUpdate = [
     .isNumeric()
     .withMessage("Sell price must be a number")
     .isFloat({ min: 0 })
-    .withMessage("Sell price cannot be negative")
-    .custom((value, { req }) => {
-      // Only validate cross-field relationship if both prices are provided
-      if (req.body.buyPrice !== undefined && value !== undefined) {
-        if (parseFloat(value) < parseFloat(req.body.buyPrice)) {
-          throw new Error(
-            "Sell price must be greater than or equal to buy price"
-          );
-        }
-      }
-      return true;
-    }),
+    .withMessage("Sell price cannot be negative"),
+    // Note: Cross-field validation (sellPrice vs buyPrice) is handled in the controller
 
   body("quantity")
     .optional()


### PR DESCRIPTION
Remove redundant and problematic cross-field price validation from the product update middleware to fix incorrect validation errors.

The `validateProductUpdate` middleware was incorrectly throwing "Sell price must be greater than or equal to buy price" errors, even when the sell price was higher. This was due to issues with the middleware's handling of JSON data types or timing. The more robust cross-field price validation is already present and correctly implemented in the `productController`, making the middleware's check redundant and error-prone. Moving this responsibility entirely to the controller ensures correct validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-427f4c4f-816e-41f4-9db2-fc9f54f33bc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-427f4c4f-816e-41f4-9db2-fc9f54f33bc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

