### PR TITLE
Fix sell price greater than buy price error

### DIFF
--- a/backend/middleware/validation.js
+++ b/backend/middleware/validation.js
@@ -39,15 +39,8 @@ export const validateProduct = [
     .isNumeric()
     .withMessage("Sell price must be a number")
     .isFloat({ min: 0 })
-    .withMessage("Sell price cannot be negative")
-    .custom((value, { req }) => {
-      if (parseFloat(value) < parseFloat(req.body.buyPrice)) {
-        throw new Error(
-          "Sell price must be greater than or equal to buy price"
-        );
-      }
-      return true;
-    }),
+    .withMessage("Sell price cannot be negative"),
+    // Cross-field validation moved to controller for better error handling
 
   body("quantity")
     .isInt({ min: 0 })
@@ -105,18 +98,9 @@ export const validateProductUpdate = [
     .isNumeric()
     .withMessage("Sell price must be a number")
     .isFloat({ min: 0 })
-    .withMessage("Sell price cannot be negative")
-    .custom((value, { req }) => {
-      // Only validate cross-field relationship if both prices are provided
-      if (req.body.buyPrice !== undefined && value !== undefined) {
-        if (parseFloat(value) < parseFloat(req.body.buyPrice)) {
-          throw new Error(
-            "Sell price must be greater than or equal to buy price"
-          );
-        }
-      }
-      return true;
-    }),
+    .withMessage("Sell price cannot be negative"),
+    // Removed cross-field validation from middleware as it's handled in controller
+    // where we have access to existing product data for proper validation
 
   body("quantity")
     .optional()

--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -23,12 +23,8 @@ const productSchema = new mongoose.Schema(
       type: Number,
       required: [true, "Sell price is required"],
       min: [0, "Sell price cannot be negative"],
-      validate: {
-        validator: function (value) {
-          return value >= this.buyPrice;
-        },
-        message: "Sell price must be greater than or equal to buy price",
-      },
+      // Removed Mongoose-level price validation to avoid conflicts with updates
+      // Price validation is handled in the controller layer for better control
     },
     quantity: {
       type: Number,


### PR DESCRIPTION
Remove conflicting Mongoose and middleware price validations to fix "sell price greater than buy price" errors by centralizing logic in the controller.

The previous Mongoose model validation and Express-validator middleware for price comparison caused issues during product updates. The Mongoose validator could use stale `buyPrice` values, and the middleware lacked access to existing product data for proper cross-field checks. This led to incorrect rejections of valid price updates. Centralizing this logic in the controller ensures accurate validation by combining new and existing data.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f02fec2-2fc5-44c0-9ad4-3efc4d4dff98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f02fec2-2fc5-44c0-9ad4-3efc4d4dff98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

